### PR TITLE
Improved flight permissions

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,5 +1,6 @@
 globals = {
 	"areas",
+	"hangglider",
 }
 
 read_globals = {

--- a/init.lua
+++ b/init.lua
@@ -190,7 +190,7 @@ local function hangglider_use(stack, player)
 	local pos = player:get_pos()
 	local name = player:get_player_name()
 	if not hanggliding_players[name] then
-		if not hangglider.allowed_to_fly(pos, name, false)
+		if not hangglider.allowed_to_fly(pos, name, false) then
 			return
 		end
 		minetest.sound_play("hanggliger_equip", {pos = pos, max_hear_distance = 8, gain = 1.0}, true)

--- a/init.lua
+++ b/init.lua
@@ -84,7 +84,7 @@ function hangglider.allowed_to_fly(pos, name, in_flight) --luacheck: no unused a
 	return true
 end
 
-local function can_fly(pos, name)
+local function friendly_airspace(pos, name)
 	if not enable_flak then
 		return true
 	end
@@ -153,7 +153,7 @@ local function hangglider_step(self, dtime)
 					})
 				end
 			end
-			if not can_fly(pos, name) then
+			if not friendly_airspace(pos, name) then
 				if not self.flak_timer then
 					self.flak_timer = 0
 					shoot_flak_sound(pos)


### PR DESCRIPTION
Gives other mods a hook to influence where hanggliders may/can fly.
E.g. disallow in vacuum or over admin base.

Also renames can_fly() to friendly_airspace() as the name was misleading.