### PR TITLE
Optimize `remove_physics_overrides()` a bit

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -71,12 +71,12 @@ local function set_physics_overrides(player, overrides)
 end
 
 local function remove_physics_overrides(player)
-	for _, name in pairs({"jump", "speed", "gravity"}) do
-		if has_player_monoids then
+	if has_player_monoids then
+		for _, name in pairs({"jump", "speed", "gravity"}) do
 			player_monoids[name]:del_change(player, "hangglider:glider")
-		else
-			player:set_physics_override({[name] = 1})
 		end
+	else
+		player:set_physics_override({jump = 1, speed = 1, gravity = 1})
 	end
 end
 


### PR DESCRIPTION
- Minor optimization, requires only 1 instead of 3 `player:set_physics_override` calls.
- Code is more consistent to the `set_physics_overrides` function